### PR TITLE
Fix Chakra UI import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,6 @@ import {
   Heading,
   Icon,
   Input,
-  Stack,
   Switch,
   Text,
   VStack,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,14 +1,12 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { ChakraProvider, extendTheme } from '@chakra-ui/react';
+import { ChakraProvider } from '@chakra-ui/react';
 import App from './App.tsx';
 import './index.css';
 
-const theme = extendTheme({});
-
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ChakraProvider theme={theme}>
+    <ChakraProvider>
       <App />
     </ChakraProvider>
   </StrictMode>


### PR DESCRIPTION
## Summary
- use default ChakraProvider instead of extendTheme in main
- remove unused Stack import

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688999805d488326b462f8e3b4827c37