### PR TITLE
Fix Chakra provider initialization

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,12 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { ChakraProvider } from '@chakra-ui/react';
+import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
 import App from './App.tsx';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ChakraProvider>
+    <ChakraProvider value={defaultSystem}>
       <App />
     </ChakraProvider>
   </StrictMode>


### PR DESCRIPTION
## Summary
- supply `defaultSystem` to `ChakraProvider`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68899ada720883269cb9b9862d1a0d71